### PR TITLE
Include RETW as return branch.

### DIFF
--- a/binja_xtensa/__init__.py
+++ b/binja_xtensa/__init__.py
@@ -121,7 +121,7 @@ class XtensaLE(Architecture):
             raise Exception("Somehow we got here without setting length")
 
         # Add branches
-        if insn.mnem in ["RET", "RET.N"]:
+        if insn.mnem in ["RET", "RET.N", "RETW", "RETW.N"]:
             result.add_branch(BranchType.FunctionReturn)
 
         # Section 3.8.4 "Jump and Call Instructions

--- a/binja_xtensa/lifter.py
+++ b/binja_xtensa/lifter.py
@@ -140,6 +140,8 @@ def _lift_RET(insn, addr, il):
     return insn.length
 
 _lift_RET_N = _lift_RET
+_lift_RETW = _lift_RET
+_lift_RETW_N = _lift_RET
 
 def _lift_L32I_N(insn, addr, il):
     _as = il.reg(4, _reg_name(insn, "as"))


### PR DESCRIPTION
During RE of an ESP32 file, I noticed quite a bit of strange behaviour surrounding the RETW and RETW.N instructions.

An example is seen here, where the same section of bytecode is re-used at the address as the RETW is not recognised:
![image](https://user-images.githubusercontent.com/3784485/230700440-30119fd2-6ba2-41ed-a4d2-e9e7519db308.png)

After making these changes, the flow seems to be a lot better:
![image](https://user-images.githubusercontent.com/3784485/230700461-d3761b55-8ceb-4471-bff8-2b3be92c9542.png)

m